### PR TITLE
Fix more close/reconnect issues

### DIFF
--- a/src/main/java/mx/kenzie/eris/network/NetworkController.java
+++ b/src/main/java/mx/kenzie/eris/network/NetworkController.java
@@ -2,32 +2,24 @@ package mx.kenzie.eris.network;
 
 import mx.kenzie.argo.Json;
 import mx.kenzie.eris.Bot;
-import mx.kenzie.eris.api.Event;
-import mx.kenzie.eris.api.Listener;
+import mx.kenzie.eris.api.*;
 import mx.kenzie.eris.api.utility.MultiBody;
 import mx.kenzie.eris.data.incoming.Incoming;
 import mx.kenzie.eris.data.incoming.gateway.*;
 import mx.kenzie.eris.data.outgoing.Outgoing;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.WebSocket;
+import java.net.http.*;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class NetworkController {
-    
+public class NetworkController implements Closeable {
+
     public static final Map<Integer, Class<? extends Incoming>> NETWORK_CODES = new HashMap<>();
-    
+
     static {
         NETWORK_CODES.put(0, Dispatch.class);
         NETWORK_CODES.put(7, Reconnect.class);
@@ -35,27 +27,41 @@ public class NetworkController {
         NETWORK_CODES.put(10, Hello.class);
         NETWORK_CODES.put(11, Heartbeat.class);
     }
-    
+
     public final Map<Integer, Class<? extends Incoming>> codes = new HashMap<>(NETWORK_CODES);
     public final Map<Listener<?>, Class<? extends Incoming>> listeners = new HashMap<>();
-    
+
     public final String base;
-    public final HttpClient client = HttpClient.newHttpClient();
     public final AtomicInteger sequence = new AtomicInteger();
-    
+
     public final Json.JsonHelper helper = new Json.JsonHelper();
     protected WebSocket socket;
+    private HttpClient client = HttpClient.newHttpClient();
     protected final Bot bot;
-    
+
     public NetworkController(String base, Bot bot) {
         this.base = base;
         this.bot = bot;
     }
-    
+
+    public HttpClient getClient() {
+        return client;
+    }
+
+    @Override
+    public void close() {
+        client = null; // Null the client to allow termination
+        if (socket != null && !socket.isOutputClosed())
+            socket.sendClose(1000, "Network controller forcibly closed socket.");
+
+        codes.clear();
+        listeners.clear();
+    }
+
     void triggerEvent(Event event) {
         this.bot.triggerEvent(event);
     }
-    
+
     @SuppressWarnings({"unchecked", "RawUseOfParameterized"})
     void triggerEvent(Incoming payload) {
         for (final Map.Entry<Listener<?>, Class<? extends Incoming>> entry : this.listeners.entrySet()) {
@@ -71,22 +77,22 @@ public class NetworkController {
             }, bot.executor);
         }
     }
-    
+
     public CompletableFuture<?> sendPayload(Outgoing payload) {
         if (Bot.DEBUG_MODE && !(payload instanceof mx.kenzie.eris.data.outgoing.gateway.Heartbeat)) System.out.println("Dispatch: " + payload.getClass().getSimpleName());
         assert socket != null;
         assert payload != null;
         return this.socket.sendText(Json.toJson(payload), true);
     }
-    
+
     public <Event extends Incoming> void registerListener(Class<Event> type, Listener<Event> listener) {
         this.listeners.put(listener, type);
     }
-    
+
     public void unregisterListener(Listener<?> listener) {
         this.listeners.remove(listener);
     }
-    
+
     public Listener<?>[] getListeners(Class<? extends Incoming> type) {
         final List<Listener<?>> list = new ArrayList<>();
         for (final Map.Entry<Listener<?>, Class<? extends Incoming>> entry : listeners.entrySet()) {
@@ -95,23 +101,23 @@ public class NetworkController {
         }
         return list.toArray(new Listener[0]);
     }
-    
+
     public void registerNetworkCode(int code, Class<? extends Incoming> payload) {
         this.codes.put(code, payload);
     }
-    
+
     public Incoming getPayload(CharSequence data) {
         try (final Json json = new Json(data.toString())) {
             return this.getPayload(json);
         }
     }
-    
+
     public Incoming getPayload(InputStream data) {
         try (final Json json = new Json(data)) {
             return this.getPayload(json);
         }
     }
-    
+
     public void notify(Integer sequence) {
         synchronized (this.sequence) {
             if (sequence == null) return;
@@ -119,7 +125,7 @@ public class NetworkController {
             this.sequence.set(sequence);
         }
     }
-    
+
     private Incoming getPayload(Json json) {
         final Map<String, Object> map = json.toMap();
         final Integer code = (Integer) map.get("op");
@@ -128,13 +134,13 @@ public class NetworkController {
         this.helper.mapToObject(payload, type, map);
         return payload;
     }
-    
+
     public WebSocket openSocket(String url) {
         final WebSocket.Builder builder = client.newWebSocketBuilder();
         this.socket = builder.buildAsync(URI.create(url), new SocketListener(this)).join();
         return socket;
     }
-    
+
     public HttpResponse<InputStream> multiRequest(String method, String path, MultiBody body, String... headers) throws IOException, InterruptedException {
         final URI uri = URI.create(base + path);
         final HttpRequest.BodyPublisher publisher;
@@ -152,7 +158,7 @@ public class NetworkController {
             .headers(list.toArray(new String[0])).build();
         return client.send(request, HttpResponse.BodyHandlers.ofInputStream());
     }
-    
+
     public HttpResponse<InputStream> request(String method, String path, String body, String... headers) throws IOException, InterruptedException {
         final URI uri = URI.create(base + path);
         final HttpRequest.BodyPublisher publisher;
@@ -168,50 +174,50 @@ public class NetworkController {
             .headers(list.toArray(new String[0])).build();
         return client.send(request, HttpResponse.BodyHandlers.ofInputStream());
     }
-    
+
     public HttpResponse<InputStream> get(String path, String... headers) throws IOException, InterruptedException {
         final URI uri = URI.create(base + path);
         final HttpRequest request = HttpRequest.newBuilder(uri).GET().headers(headers).build();
         return client.send(request, HttpResponse.BodyHandlers.ofInputStream());
     }
-    
+
     public HttpResponse<InputStream> post(String path, InputStream stream, String... headers) throws IOException, InterruptedException {
         final HttpRequest.BodyPublisher publisher = HttpRequest.BodyPublishers.ofInputStream(() -> stream);
         return this.post(path, publisher, headers);
     }
-    
+
     public HttpResponse<InputStream> post(String path, Path file, String... headers) throws IOException, InterruptedException {
         final HttpRequest.BodyPublisher publisher = HttpRequest.BodyPublishers.ofFile(file);
         return this.post(path, publisher, headers);
     }
-    
+
     public HttpResponse<InputStream> post(String path, String body, String... headers) throws IOException, InterruptedException {
         final HttpRequest.BodyPublisher publisher = HttpRequest.BodyPublishers.ofString(body);
         return this.post(path, publisher, headers);
     }
-    
+
     public HttpResponse<InputStream> patch(String path, String body, String... headers) throws IOException, InterruptedException {
         final HttpRequest.BodyPublisher publisher = HttpRequest.BodyPublishers.ofString(body);
         return this.patch(path, publisher, headers);
     }
-    
+
     public HttpResponse<Void> delete(String path, String... headers) throws IOException, InterruptedException {
         final URI uri = URI.create(base + path);
         final HttpRequest request = HttpRequest.newBuilder(uri).DELETE().headers(headers).build();
         return client.send(request, HttpResponse.BodyHandlers.discarding());
     }
-    
+
     protected HttpResponse<InputStream> post(String path, HttpRequest.BodyPublisher publisher, String... headers) throws IOException, InterruptedException {
         final URI uri = URI.create(base + path);
         final HttpRequest request = HttpRequest.newBuilder(uri).POST(publisher).headers(headers).build();
         return client.send(request, HttpResponse.BodyHandlers.ofInputStream());
     }
-    
+
     protected HttpResponse<InputStream> patch(String path, HttpRequest.BodyPublisher publisher, String... headers) throws IOException, InterruptedException {
         final URI uri = URI.create(base + path);
         final HttpRequest request = HttpRequest.newBuilder(uri).method("PATCH", publisher).headers(headers).build();
         return client.send(request, HttpResponse.BodyHandlers.ofInputStream());
     }
-    
-    
+
+
 }


### PR DESCRIPTION
This PR fixes an issue where the bot would not reconnect after failed attempts to reconnect, and an issue where the bot would not close its executor services appropriately, leaving to applications being hung as inaccessible executors were still active.